### PR TITLE
discard unneeded copies of child resources as we go

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -1033,7 +1033,6 @@ func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(r
 				continue
 			}
 			visited[key] = 1
-			// make sure children has no duplicates
 			for _, child := range childrenByUID[key] {
 				if visited[child.ResourceKey()] == 0 && action(child, nsNodes) {
 					child.iterateChildrenV2(graph, nsNodes, visited, func(err error, child *Resource, namespaceResources map[kube.ResourceKey]*Resource) bool {


### PR DESCRIPTION
Changes:
* discard dupe UID child nodes as we go instead of collecting them and then skipping all but the first; saves memory
* fix misnamed vars in `bulidGraph` - I just got them swapped in the last PR
* set up benchmarks more nicely
* add a benchmark for the old IterateHierarchy - commented out because it's hella slow

`buildGraph` benchmark before and after:

```
BenchmarkBuildGraph-16                         7         156460208 ns/op        68195956 B/op     375487 allocs/op
BenchmarkBuildGraph-16                         7         150883232 ns/op        63019392 B/op     275458 allocs/op
```

So we save a little time, a little memory, and a lot of allocations.