### PR TITLE
use nsNodes instead of dupe map

### DIFF
--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -1051,12 +1051,6 @@ func (c *clusterCache) IterateHierarchyV2(keys []kube.ResourceKey, action func(r
 	}
 }
 
-type graphKey struct {
-	kind       string
-	apiVersion string
-	name       string
-}
-
 func buildGraph(nsNodes map[kube.ResourceKey]*Resource) map[kube.ResourceKey]map[types.UID]*Resource {
 	// Prepare to construct a graph
 	nodesByUID := make(map[types.UID][]*Resource, len(nsNodes))

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -1066,7 +1066,11 @@ func buildGraph(nsNodes map[kube.ResourceKey]*Resource) map[kube.ResourceKey]map
 		for i, ownerRef := range childNode.OwnerRefs {
 			// First, backfill UID of inferred owner child references.
 			if ownerRef.UID == "" {
-				group, _ := schema.ParseGroupVersion(ownerRef.APIVersion)
+				group, err := schema.ParseGroupVersion(ownerRef.APIVersion)
+				if err != nil {
+					// APIVersion is invalid, so we couldn't find the parent.
+					continue
+				}
 				graphKeyNode, ok := nsNodes[kube.ResourceKey{Group: group.Group, Kind: ownerRef.Kind, Namespace: childNode.Ref.Namespace, Name: ownerRef.Name}]
 				if ok {
 					ownerRef.UID = graphKeyNode.Ref.UID

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -1060,10 +1060,8 @@ type graphKey struct {
 func buildGraph(nsNodes map[kube.ResourceKey]*Resource) map[kube.ResourceKey]map[types.UID]*Resource {
 	// Prepare to construct a graph
 	nodesByUID := make(map[types.UID][]*Resource, len(nsNodes))
-	nodeByGraphKey := make(map[graphKey]*Resource, len(nsNodes))
 	for _, node := range nsNodes {
 		nodesByUID[node.Ref.UID] = append(nodesByUID[node.Ref.UID], node)
-		nodeByGraphKey[graphKey{node.Ref.Kind, node.Ref.APIVersion, node.Ref.Name}] = node
 	}
 
 	// In graph, they key is the parent and the value is a list of children.
@@ -1074,7 +1072,8 @@ func buildGraph(nsNodes map[kube.ResourceKey]*Resource) map[kube.ResourceKey]map
 		for i, ownerRef := range childNode.OwnerRefs {
 			// First, backfill UID of inferred owner child references.
 			if ownerRef.UID == "" {
-				graphKeyNode, ok := nodeByGraphKey[graphKey{ownerRef.Kind, ownerRef.APIVersion, ownerRef.Name}]
+				group, _ := schema.ParseGroupVersion(ownerRef.APIVersion)
+				graphKeyNode, ok := nsNodes[kube.ResourceKey{Group: group.Group, Kind: ownerRef.Kind, Namespace: childNode.Ref.Namespace, Name: ownerRef.Name}]
 				if ok {
 					ownerRef.UID = graphKeyNode.Ref.UID
 					childNode.OwnerRefs[i] = ownerRef


### PR DESCRIPTION
I'm a little worried about this one.

Before/after benchmark:

```
BenchmarkBuildGraph-16                        10         105016242 ns/op        25624409 B/op     133775 allocs/op
BenchmarkBuildGraph-16                        15          72923367 ns/op        16766516 B/op     132153 allocs/op
```

Enough of a win to be tempting.

Argo CD unit tests pass, waiting on e2e tests: https://github.com/argoproj/argo-cd/pull/19090